### PR TITLE
feat: support vite 3

### DIFF
--- a/.changeset/unlucky-moons-battle.md
+++ b/.changeset/unlucky-moons-battle.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-qrcode': major
+---
+
+Support Vite 3

--- a/.changeset/witty-seas-fetch.md
+++ b/.changeset/witty-seas-fetch.md
@@ -1,0 +1,5 @@
+---
+'vite-plugin-qrcode': major
+---
+
+Update filter function to accept full url

--- a/README.md
+++ b/README.md
@@ -27,32 +27,9 @@ export default defineConfig({
 ```bash
 # start vite with host to show qrcode
 vite --host
-
-  vite v2.6.1 dev server running at:
-
-  > Local:    http://localhost:3000/
-  > Network:  http://192.168.2.169:3000/
-
-  ready in 186ms.
-
-  Visit page on mobile:
-  http://192.168.2.169:3000/
-  ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-  █ ▄▄▄▄▄ ██▄▄ ▀▄██▄█ ▄▄▄▄▄ █
-  █ █   █ █▀▄  █▀ ▀ █ █   █ █
-  █ █▄▄▄█ █▄▀ █▄▀ ███ █▄▄▄█ █
-  █▄▄▄▄▄▄▄█▄▀▄█ █▄▀▄█▄▄▄▄▄▄▄█
-  █ ▄██▀ ▄ █▄ █▄ █  ▀██  ▀▀██
-  ██▄▀▀█▀▄▄█▄▀ ▄█▀ ▀█▄▄▀ █▄ █
-  █ ▀ ▄▄ ▄██▄ █ ▀ ▀▄▄▄████▀▄█
-  █ █▀▄█ ▄    ▀█▄▀▄▀▄█▄▀▄▀▄ █
-  █▄█████▄█▀█▄  ▄▀▀ ▄▄▄ █ ███
-  █ ▄▄▄▄▄ █ ██▄ █ █ █▄█ ▄██▄█
-  █ █   █ ██▀ ▀▀▄█▄▄▄  ▄ ▄▀▀█
-  █ █▄▄▄█ █▀█▄█ ██▀▀▄▀▀▀█▄█ █
-  █▄▄▄▄▄▄▄█▄██▄██▄▄▄█▄██▄██▄█
-
 ```
+
+![CLI output](https://user-images.githubusercontent.com/34116392/181014171-aa511838-8122-48cf-ad9c-39f0368ee616.png)
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ export default defineConfig({
 vite --host
 ```
 
-![CLI output](https://user-images.githubusercontent.com/34116392/181014171-aa511838-8122-48cf-ad9c-39f0368ee616.png)
+<img height="360" alt="CLI output" src="https://user-images.githubusercontent.com/34116392/181014171-aa511838-8122-48cf-ad9c-39f0368ee616.png" />
 
 ## Packages
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.24.1",
     "@svitejs/changesets-changelog-github-compact": "^0.1.1",
-    "@types/node": "^16.11.45",
+    "@types/node": "^18.6.1",
     "@typescript-eslint/eslint-plugin": "^5.31.0",
     "@typescript-eslint/parser": "^5.31.0",
     "cross-env": "^7.0.3",
@@ -47,6 +47,6 @@
   },
   "packageManager": "pnpm@7.1.9",
   "engines": {
-    "node": "^14.13.1 || ^16.0.0 || >=18"
+    "node": "^14.18.0 || ^16.0.0 || >=18"
   }
 }

--- a/packages/playground/basic/package.json
+++ b/packages/playground/basic/package.json
@@ -9,7 +9,7 @@
     "serve": "vite preview"
   },
   "devDependencies": {
-    "vite": "^2.9.14",
+    "vite": "^3.0.3",
     "vite-plugin-qrcode": "workspace:*"
   }
 }

--- a/packages/playground/sveltekit/package.json
+++ b/packages/playground/sveltekit/package.json
@@ -8,9 +8,9 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@sveltejs/kit": "1.0.0-next.372",
+    "@sveltejs/kit": "^1.0.0-next.394",
     "svelte": "^3.49.0",
-    "vite": "^2.9.14",
+    "vite": "^3.0.3",
     "vite-plugin-qrcode": "workspace:*"
   },
   "type": "module"

--- a/packages/vite-plugin-qrcode/README.md
+++ b/packages/vite-plugin-qrcode/README.md
@@ -26,7 +26,7 @@ export default defineConfig({
 vite --host
 ```
 
-![CLI output](https://user-images.githubusercontent.com/34116392/181014171-aa511838-8122-48cf-ad9c-39f0368ee616.png)
+<img height="360" alt="CLI output" src="https://user-images.githubusercontent.com/34116392/181014171-aa511838-8122-48cf-ad9c-39f0368ee616.png" />
 
 ## Options
 

--- a/packages/vite-plugin-qrcode/README.md
+++ b/packages/vite-plugin-qrcode/README.md
@@ -24,32 +24,9 @@ export default defineConfig({
 ```bash
 # start vite with host to show qrcode
 vite --host
-
-  vite v2.6.1 dev server running at:
-
-  > Local:    http://localhost:3000/
-  > Network:  http://192.168.2.169:3000/
-
-  ready in 186ms.
-
-  Visit page on mobile:
-  http://192.168.2.169:3000/
-  ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-  █ ▄▄▄▄▄ ██▄▄ ▀▄██▄█ ▄▄▄▄▄ █
-  █ █   █ █▀▄  █▀ ▀ █ █   █ █
-  █ █▄▄▄█ █▄▀ █▄▀ ███ █▄▄▄█ █
-  █▄▄▄▄▄▄▄█▄▀▄█ █▄▀▄█▄▄▄▄▄▄▄█
-  █ ▄██▀ ▄ █▄ █▄ █  ▀██  ▀▀██
-  ██▄▀▀█▀▄▄█▄▀ ▄█▀ ▀█▄▄▀ █▄ █
-  █ ▀ ▄▄ ▄██▄ █ ▀ ▀▄▄▄████▀▄█
-  █ █▀▄█ ▄    ▀█▄▀▄▀▄█▄▀▄▀▄ █
-  █▄█████▄█▀█▄  ▄▀▀ ▄▄▄ █ ███
-  █ ▄▄▄▄▄ █ ██▄ █ █ █▄█ ▄██▄█
-  █ █   █ ██▀ ▀▀▄█▄▄▄  ▄ ▄▀▀█
-  █ █▄▄▄█ █▀█▄█ ██▀▀▄▀▀▀█▄█ █
-  █▄▄▄▄▄▄▄█▄██▄██▄▄▄█▄██▄██▄█
-
 ```
+
+![CLI output](https://user-images.githubusercontent.com/34116392/181014171-aa511838-8122-48cf-ad9c-39f0368ee616.png)
 
 ## Options
 
@@ -64,7 +41,7 @@ Example:
 import { qrcode } from 'vite-plugin-qrcode';
 
 export default defineConfig({
-	plugins: [qrcode({ filter: (ip) => ip === '192.168.1.1' })]
+	plugins: [qrcode({ filter: (url) => url === 'http://192.168.1.1:4173' })]
 });
 ```
 

--- a/packages/vite-plugin-qrcode/package.json
+++ b/packages/vite-plugin-qrcode/package.json
@@ -51,6 +51,6 @@
     "@types/qrcode-terminal": "^0.12.0",
     "rollup": "^2.77.1",
     "uvu": "^0.5.6",
-    "vite": "^2.9.14"
+    "vite": "^3.0.3"
   }
 }

--- a/packages/vite-plugin-qrcode/package.json
+++ b/packages/vite-plugin-qrcode/package.json
@@ -45,7 +45,7 @@
     "qrcode-terminal": "^0.12.0"
   },
   "peerDependencies": {
-    "vite": "^2.6.1"
+    "vite": "^3.0.0"
   },
   "devDependencies": {
     "@types/qrcode-terminal": "^0.12.0",

--- a/packages/vite-plugin-qrcode/src/index.ts
+++ b/packages/vite-plugin-qrcode/src/index.ts
@@ -54,9 +54,9 @@ export interface PluginOptions {
 	 * filter list of shown QR codes. Useful if you have multiple interfaces and only need one
 	 *
 	 *  examples:
-	 *    ip => ip.startsWith('http://192.')
-	 *    ip => !ip.startsWith('http://172.)
-	 *    ip => ip === 'http://192.168.1.70:4173'
+	 *    url => url.startsWith('http://192.')
+	 *    url => !url.startsWith('http://172.)
+	 *    url => url === 'http://192.168.1.70:4173'
 	 *
 	 * @param url {string} ip address
 	 * @returns {boolean}

--- a/packages/vite-plugin-qrcode/src/index.ts
+++ b/packages/vite-plugin-qrcode/src/index.ts
@@ -1,5 +1,3 @@
-import os from 'os';
-import { AddressInfo } from 'net';
 import type { Plugin, ViteDevServer } from 'vite';
 import qr from 'qrcode-terminal';
 
@@ -26,13 +24,19 @@ export function qrcode(options: PluginOptions = {}): Plugin {
 }
 
 function logQrcode(server: ViteDevServer, options: PluginOptions) {
-	const networkUrls = getNetworkUrls(server, options);
+	let networkUrls = server.resolvedUrls?.network;
+
+	if (!networkUrls) return;
+
+	if (options.filter) {
+		networkUrls = networkUrls.filter(options.filter);
+	}
 
 	if (networkUrls.length === 0) return;
 
 	const info = server.config.logger.info;
 
-	info('  Visit page on mobile:');
+	info('\n  Visit page on mobile:');
 
 	for (const url of networkUrls) {
 		qr.generate(url, { small: true }, (result) => {
@@ -45,82 +49,18 @@ function cyan(str: string): string {
 	return `\x1b[36m${str}\x1b[0m`;
 }
 
-// Referenced from https://github.com/vitejs/vite/blob/77447496704e61cdb68b5788d8d79f19a2d895f1/packages/vite/src/node/logger.ts#L143
-function getNetworkUrls(server: ViteDevServer, options: PluginOptions): string[] {
-	const address = server.httpServer?.address();
-
-	if (!isAddressInfo(address)) return [];
-
-	const hostname = resolveHostname(server.config.server.host);
-
-	if (hostname.host === '127.0.0.1') return [];
-
-	const protocol = server.config.server.https ? 'https' : 'http';
-	const port = address.port;
-	const base = server.config.base;
-
-	return Object.values(os.networkInterfaces())
-		.flatMap((nInterface) => nInterface ?? [])
-		.filter(
-			(detail) =>
-				detail &&
-				detail.address &&
-				// @ts-ignore node18 returns a number
-				(detail.family === 'IPv4' || detail.family === 4) &&
-				!detail.address.includes('127.0.0.1') &&
-				(!options.filter || options.filter(detail.address))
-		)
-		.map((detail) => `${protocol}://${detail.address}:${port}${base}`);
-}
-
-function isAddressInfo(v: any): v is AddressInfo {
-	return v.address;
-}
-
-// Copied from https://github.com/vitejs/vite/blob/77447496704e61cdb68b5788d8d79f19a2d895f1/packages/vite/src/node/utils.ts#L531
-function resolveHostname(optionsHost: string | boolean | undefined): Hostname {
-	let host: string | undefined;
-	if (optionsHost === undefined || optionsHost === false || optionsHost === 'localhost') {
-		// Use a secure default
-		host = '127.0.0.1';
-	} else if (optionsHost === true) {
-		// If passed --host in the CLI without arguments
-		host = undefined; // undefined typically means 0.0.0.0 or :: (listen on all IPs)
-	} else {
-		host = optionsHost;
-	}
-
-	// Set host name to localhost when possible, unless the user explicitly asked for '127.0.0.1'
-	const name =
-		(optionsHost !== '127.0.0.1' && host === '127.0.0.1') ||
-		host === '0.0.0.0' ||
-		host === '::' ||
-		host === undefined
-			? 'localhost'
-			: host;
-
-	return { host, name };
-}
-
-interface Hostname {
-	// undefined sets the default behaviour of server.listen
-	host: string | undefined;
-	// resolve to localhost when possible
-	name: string;
-}
-
 export interface PluginOptions {
 	/**
 	 * filter list of shown QR codes. Useful if you have multiple interfaces and only need one
 	 *
 	 *  examples:
-	 *    ip => ip.startsWith('192.')
-	 *    ip => !ip.startsWith('172.)
-	 *    ip => ip === '192.168.1.70'
+	 *    ip => ip.startsWith('http://192.')
+	 *    ip => !ip.startsWith('http://172.)
+	 *    ip => ip === 'http://192.168.1.70:4173'
 	 *
-	 * @param ip {string} ip address
+	 * @param url {string} ip address
 	 * @returns {boolean}
 	 */
 	// eslint-disable-next-line no-unused-vars
-	filter?: (ip: string) => boolean;
+	filter?: (url: string) => boolean;
 }

--- a/packages/vite-plugin-qrcode/tsup.config.js
+++ b/packages/vite-plugin-qrcode/tsup.config.js
@@ -4,5 +4,5 @@ export const tsup = {
 	format: ['esm', 'cjs'],
 	splitting: false,
 	clean: true,
-	target: 'node14.13.1'
+	target: 'node14.18.0'
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ importers:
     specifiers:
       '@changesets/cli': ^2.24.1
       '@svitejs/changesets-changelog-github-compact': ^0.1.1
-      '@types/node': ^16.11.45
+      '@types/node': ^18.6.1
       '@typescript-eslint/eslint-plugin': ^5.31.0
       '@typescript-eslint/parser': ^5.31.0
       cross-env: ^7.0.3
@@ -30,7 +30,7 @@ importers:
     devDependencies:
       '@changesets/cli': 2.24.1
       '@svitejs/changesets-changelog-github-compact': 0.1.1
-      '@types/node': 16.11.45
+      '@types/node': 18.6.1
       '@typescript-eslint/eslint-plugin': 5.31.0_d5zwcxr4bwkhmuo464cb3a2puu
       '@typescript-eslint/parser': 5.31.0_he2ccbldppg44uulnyq4rwocfa
       cross-env: 7.0.3
@@ -54,22 +54,22 @@ importers:
 
   packages/playground/basic:
     specifiers:
-      vite: ^2.9.14
+      vite: ^3.0.3
       vite-plugin-qrcode: workspace:*
     devDependencies:
-      vite: 2.9.14
+      vite: 3.0.3
       vite-plugin-qrcode: link:../../vite-plugin-qrcode
 
   packages/playground/sveltekit:
     specifiers:
-      '@sveltejs/kit': 1.0.0-next.372
+      '@sveltejs/kit': ^1.0.0-next.394
       svelte: ^3.49.0
-      vite: ^2.9.14
+      vite: ^3.0.3
       vite-plugin-qrcode: workspace:*
     devDependencies:
-      '@sveltejs/kit': 1.0.0-next.372_svelte@3.49.0+vite@2.9.14
+      '@sveltejs/kit': 1.0.0-next.394_svelte@3.49.0+vite@3.0.3
       svelte: 3.49.0
-      vite: 2.9.14
+      vite: 3.0.3
       vite-plugin-qrcode: link:../../vite-plugin-qrcode
 
   packages/vite-plugin-qrcode:
@@ -78,14 +78,14 @@ importers:
       qrcode-terminal: ^0.12.0
       rollup: ^2.77.1
       uvu: ^0.5.6
-      vite: ^2.9.14
+      vite: ^3.0.3
     dependencies:
       qrcode-terminal: 0.12.0
     devDependencies:
       '@types/qrcode-terminal': 0.12.0
       rollup: 2.77.1
       uvu: 0.5.6
-      vite: 2.9.14
+      vite: 3.0.3
 
 packages:
 
@@ -345,7 +345,7 @@ packages:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
       '@babel/runtime': 7.16.3
-      '@types/node': 12.20.37
+      '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
     dev: true
@@ -390,31 +390,31 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@sveltejs/kit/1.0.0-next.372_svelte@3.49.0+vite@2.9.14:
-    resolution: {integrity: sha512-pcnDfV8YQwj7d/SCaKWT7yPBrmgkPH9Dc4UIeX8yTLXDu8IPzI5kukEOy4xf6LjyJsuSGPy1Ch91ULugtVIdAQ==}
+  /@sveltejs/kit/1.0.0-next.394_svelte@3.49.0+vite@3.0.3:
+    resolution: {integrity: sha512-YfRNSKdbvihHFvmQodaMlChcyf9dfU36FwK8WYQF5jqEmiRajLBb/ooU6RqPA0Z6j5okJHDSYBwxW8TP+nc+gg==}
     engines: {node: '>=16.9'}
     hasBin: true
     peerDependencies:
       svelte: ^3.44.0
-      vite: ^2.9.10
+      vite: ^3.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 1.0.0-next.49_svelte@3.49.0+vite@2.9.14
+      '@sveltejs/vite-plugin-svelte': 1.0.1_svelte@3.49.0+vite@3.0.3
       chokidar: 3.5.3
       sade: 1.8.1
       svelte: 3.49.0
-      vite: 2.9.14
+      vite: 3.0.3
     transitivePeerDependencies:
       - diff-match-patch
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte/1.0.0-next.49_svelte@3.49.0+vite@2.9.14:
-    resolution: {integrity: sha512-AKh0Ka8EDgidnxWUs8Hh2iZLZovkETkefO99XxZ4sW4WGJ7VFeBx5kH/NIIGlaNHLcrIvK3CK0HkZwC3Cici0A==}
-    engines: {node: ^14.13.1 || >= 16}
+  /@sveltejs/vite-plugin-svelte/1.0.1_svelte@3.49.0+vite@3.0.3:
+    resolution: {integrity: sha512-PorCgUounn0VXcpeJu+hOweZODKmGuLHsLomwqSj+p26IwjjGffmYQfVHtiTWq+NqaUuuHWWG7vPge6UFw4Aeg==}
+    engines: {node: ^14.18.0 || >= 16}
     peerDependencies:
       diff-match-patch: ^1.0.5
       svelte: ^3.44.0
-      vite: ^2.9.0
+      vite: ^3.0.0
     peerDependenciesMeta:
       diff-match-patch:
         optional: true
@@ -426,7 +426,7 @@ packages:
       magic-string: 0.26.2
       svelte: 3.49.0
       svelte-hmr: 0.14.12_svelte@3.49.0
-      vite: 2.9.14
+      vite: 3.0.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -461,12 +461,12 @@ packages:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
     dev: true
 
-  /@types/node/12.20.37:
-    resolution: {integrity: sha512-i1KGxqcvJaLQali+WuypQnXwcplhtNtjs66eNsZpp2P2FL/trJJxx/VWsM0YCL2iMoIJrbXje48lvIQAQ4p2ZA==}
+  /@types/node/12.20.55:
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node/16.11.45:
-    resolution: {integrity: sha512-3rKg/L5x0rofKuuUt5zlXzOnKyIHXmIu5R8A0TuNDMF2062/AOIDBciFIjToLEJ/9F9DzkHNot+BpNsMI1OLdQ==}
+  /@types/node/18.6.1:
+    resolution: {integrity: sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==}
     dev: true
 
   /@types/normalize-package-data/2.4.1:
@@ -1204,8 +1204,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-android-64/0.14.50:
+    resolution: {integrity: sha512-H7iUEm7gUJHzidsBlFPGF6FTExazcgXL/46xxLo6i6bMtPim6ZmXyTccS8yOMpy6HAC6dPZ/JCQqrkkin69n6Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-android-arm64/0.14.30:
     resolution: {integrity: sha512-BdgGfxeA5hBQNErLr7BWJUA8xjflEfyaARICy8e0OJYNSAwDbEzOf8LyiKWSrDcgV129mWhi3VpbNQvOIDEHcg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64/0.14.50:
+    resolution: {integrity: sha512-NFaoqEwa+OYfoYVpQWDMdKII7wZZkAjtJFo1WdnBeCYlYikvUhTnf2aPwPu5qEAw/ie1NYK0yn3cafwP+kP+OQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -1222,8 +1240,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-darwin-64/0.14.50:
+    resolution: {integrity: sha512-gDQsCvGnZiJv9cfdO48QqxkRV8oKAXgR2CGp7TdIpccwFdJMHf8hyIJhMW/05b/HJjET/26Us27Jx91BFfEVSA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-darwin-arm64/0.14.30:
     resolution: {integrity: sha512-qDez+fHMOrO9Oc9qjt/x+sy09RJVh62kik5tVybKRLmezeV4qczM9/sAYY57YN0aWLdHbcCj2YqJUWYJNsgKnw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.14.50:
+    resolution: {integrity: sha512-36nNs5OjKIb/Q50Sgp8+rYW/PqirRiFN0NFc9hEvgPzNJxeJedktXwzfJSln4EcRFRh5Vz4IlqFRScp+aiBBzA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -1240,8 +1276,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-freebsd-64/0.14.50:
+    resolution: {integrity: sha512-/1pHHCUem8e/R86/uR+4v5diI2CtBdiWKiqGuPa9b/0x3Nwdh5AOH7lj+8823C6uX1e0ufwkSLkS+aFZiBCWxA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-freebsd-arm64/0.14.30:
     resolution: {integrity: sha512-cpjbTs6Iok/AfeB0JgTzyUJTMStC1SQULmany5nHx6S4GTkSgaAHuJzZO0GcVWqghI4e0YL/bjXAhN5Mn6feNw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.14.50:
+    resolution: {integrity: sha512-iKwUVMQztnPZe5pUYHdMkRc9aSpvoV1mkuHlCoPtxZA3V+Kg/ptpzkcSY+fKd0kuom+l6Rc93k0UPVkP7xoqrw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -1258,8 +1312,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-32/0.14.50:
+    resolution: {integrity: sha512-sWUwvf3uz7dFOpLzYuih+WQ7dRycrBWHCdoXJ4I4XdMxEHCECd8b7a9N9u7FzT6XR2gHPk9EzvchQUtiEMRwqw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-64/0.14.30:
     resolution: {integrity: sha512-LUnpzoMpRqFON5En4qEj6NWiyH6a1K+Y2qYNKrCy5qPTjDoG/EWeqMz69n8Uv7pRuvDKl3FNGJ1dufTrA5i0sw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.14.50:
+    resolution: {integrity: sha512-u0PQxPhaeI629t4Y3EEcQ0wmWG+tC/LpP2K7yDFvwuPq0jSQ8SIN+ARNYfRjGW15O2we3XJvklbGV0wRuUCPig==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -1276,8 +1348,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-arm/0.14.50:
+    resolution: {integrity: sha512-VALZq13bhmFJYFE/mLEb+9A0w5vo8z+YDVOWeaf9vOTrSC31RohRIwtxXBnVJ7YKLYfEMzcgFYf+OFln3Y0cWg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-arm64/0.14.30:
     resolution: {integrity: sha512-DHZHn6FK5q/KL0fpNT/0jE38Nnyk2rXxKE9WENi95EXtqfOLPgE8tzjTZQNgpr61R95QX4ymQU26ni3IZk8buQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.14.50:
+    resolution: {integrity: sha512-ZyfoNgsTftD7Rp5S7La5auomKdNeB3Ck+kSKXC4pp96VnHyYGjHHXWIlcbH8i+efRn9brszo1/Thl1qn8RqmhQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -1294,8 +1384,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-mips64le/0.14.50:
+    resolution: {integrity: sha512-ygo31Vxn/WrmjKCHkBoutOlFG5yM9J2UhzHb0oWD9O61dGg+Hzjz9hjf5cmM7FBhAzdpOdEWHIrVOg2YAi6rTw==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-ppc64le/0.14.30:
     resolution: {integrity: sha512-2Oudm2WEfj0dNU9bzIl5L/LrsMEmHWsOsYgJJqu8fDyUDgER+J1d33qz3cUdjsJk7gAENayIxDSpsuCszx0w3A==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.14.50:
+    resolution: {integrity: sha512-xWCKU5UaiTUT6Wz/O7GKP9KWdfbsb7vhfgQzRfX4ahh5NZV4ozZ4+SdzYG8WxetsLy84UzLX3Pi++xpVn1OkFQ==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -1312,8 +1420,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-linux-riscv64/0.14.50:
+    resolution: {integrity: sha512-0+dsneSEihZTopoO9B6Z6K4j3uI7EdxBP7YSF5rTwUgCID+wHD3vM1gGT0m+pjCW+NOacU9kH/WE9N686FHAJg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-linux-s390x/0.14.30:
     resolution: {integrity: sha512-OZ68r7ok6qO7hdwrwQn2p5jbIRRcUcVaAykB7e0uCA0ODwfeGunILM6phJtq2Oz4dlEEFvd+tSuma3paQKwt+A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.14.50:
+    resolution: {integrity: sha512-tVjqcu8o0P9H4StwbIhL1sQYm5mWATlodKB6dpEZFkcyTI8kfIGWiWcrGmkNGH2i1kBUOsdlBafPxR3nzp3TDA==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -1330,8 +1456,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-netbsd-64/0.14.50:
+    resolution: {integrity: sha512-0R/glfqAQ2q6MHDf7YJw/TulibugjizBxyPvZIcorH0Mb7vSimdHy0XF5uCba5CKt+r4wjax1mvO9lZ4jiAhEg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-openbsd-64/0.14.30:
     resolution: {integrity: sha512-UyK1MTMcy4j5fH260fsE1o6MVgWNhb62eCK2yCKCRazZv8Nqdc2WiP9ygjWidmEdCDS+A6MuVp9ozk9uoQtQpA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64/0.14.50:
+    resolution: {integrity: sha512-7PAtmrR5mDOFubXIkuxYQ4bdNS6XCK8AIIHUiZxq1kL8cFIH5731jPcXQ4JNy/wbj1C9sZ8rzD8BIM80Tqk29w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -1348,8 +1492,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-sunos-64/0.14.50:
+    resolution: {integrity: sha512-gBxNY/wyptvD7PkHIYcq7se6SQEXcSC8Y7mE0FJB+CGgssEWf6vBPfTTZ2b6BWKnmaP6P6qb7s/KRIV5T2PxsQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-32/0.14.30:
     resolution: {integrity: sha512-9/fb1tPtpacMqxAXp3fGHowUDg/l9dVch5hKmCLEZC6PdGljh6h372zMdJwYfH0Bd5CCPT0Wx95uycBLJiqpXA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-32/0.14.50:
+    resolution: {integrity: sha512-MOOe6J9cqe/iW1qbIVYSAqzJFh0p2LBLhVUIWdMVnNUNjvg2/4QNX4oT4IzgDeldU+Bym9/Tn6+DxvUHJXL5Zw==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -1366,8 +1528,26 @@ packages:
     dev: true
     optional: true
 
+  /esbuild-windows-64/0.14.50:
+    resolution: {integrity: sha512-r/qE5Ex3w1jjGv/JlpPoWB365ldkppUlnizhMxJgojp907ZF1PgLTuW207kgzZcSCXyquL9qJkMsY+MRtaZ5yQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /esbuild-windows-arm64/0.14.30:
     resolution: {integrity: sha512-F1kLyQH7zSgjh5eLxogGZN7C9+KNs9m+s7Q6WZoMmCWT/6j998zlaoECHyM8izJRRfsvw2eZlEa1jO6/IOU1AQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.14.50:
+    resolution: {integrity: sha512-EMS4lQnsIe12ZyAinOINx7eq2mjpDdhGZZWDwPZE/yUTN9cnc2Ze/xUTYIAyaJqrqQda3LnDpADKpvLvol6ENQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -1401,6 +1581,34 @@ packages:
       esbuild-windows-32: 0.14.30
       esbuild-windows-64: 0.14.30
       esbuild-windows-arm64: 0.14.30
+    dev: true
+
+  /esbuild/0.14.50:
+    resolution: {integrity: sha512-SbC3k35Ih2IC6trhbMYW7hYeGdjPKf9atTKwBUHqMCYFZZ9z8zhuvfnZihsnJypl74FjiAKjBRqFkBkAd0rS/w==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      esbuild-android-64: 0.14.50
+      esbuild-android-arm64: 0.14.50
+      esbuild-darwin-64: 0.14.50
+      esbuild-darwin-arm64: 0.14.50
+      esbuild-freebsd-64: 0.14.50
+      esbuild-freebsd-arm64: 0.14.50
+      esbuild-linux-32: 0.14.50
+      esbuild-linux-64: 0.14.50
+      esbuild-linux-arm: 0.14.50
+      esbuild-linux-arm64: 0.14.50
+      esbuild-linux-mips64le: 0.14.50
+      esbuild-linux-ppc64le: 0.14.50
+      esbuild-linux-riscv64: 0.14.50
+      esbuild-linux-s390x: 0.14.50
+      esbuild-netbsd-64: 0.14.50
+      esbuild-openbsd-64: 0.14.50
+      esbuild-sunos-64: 0.14.50
+      esbuild-windows-32: 0.14.50
+      esbuild-windows-64: 0.14.50
+      esbuild-windows-arm64: 0.14.50
     dev: true
 
   /escalade/3.1.1:
@@ -2106,6 +2314,12 @@ packages:
 
   /is-core-module/2.8.1:
     resolution: {integrity: sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==}
+    dependencies:
+      has: 1.0.3
+    dev: true
+
+  /is-core-module/2.9.0:
+    resolution: {integrity: sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==}
     dependencies:
       has: 1.0.3
     dev: true
@@ -2891,8 +3105,8 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /postcss/8.4.13:
-    resolution: {integrity: sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==}
+  /postcss/8.4.14:
+    resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.4
@@ -3069,6 +3283,15 @@ packages:
     hasBin: true
     dependencies:
       is-core-module: 2.8.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+    dev: true
+
+  /resolve/1.22.1:
+    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.9.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -3650,14 +3873,15 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite/2.9.14:
-    resolution: {integrity: sha512-P/UCjSpSMcE54r4mPak55hWAZPlyfS369svib/gpmz8/01L822lMPOJ/RYW6tLCe1RPvMvOsJ17erf55bKp4Hw==}
-    engines: {node: '>=12.2.0'}
+  /vite/3.0.3:
+    resolution: {integrity: sha512-sDIpIcl3mv1NUaSzZwiXGEy1ZoWwwC2vkxUHY6yiDacR6zf//ZFuBJrozO62gedpE43pmxnLATNR5IYUdAEkMQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
       less: '*'
       sass: '*'
       stylus: '*'
+      terser: ^5.4.0
     peerDependenciesMeta:
       less:
         optional: true
@@ -3665,10 +3889,12 @@ packages:
         optional: true
       stylus:
         optional: true
+      terser:
+        optional: true
     dependencies:
-      esbuild: 0.14.30
-      postcss: 8.4.13
-      resolve: 1.22.0
+      esbuild: 0.14.50
+      postcss: 8.4.14
+      resolve: 1.22.1
       rollup: 2.77.1
     optionalDependencies:
       fsevents: 2.3.2


### PR DESCRIPTION
- Only support Vite 3
- Filter function accept full URLs now, e.g. `http://192.168.1.1:4173`
- Update node to 14.18 to match Vite

Fix #43